### PR TITLE
Add compatibility with ES modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
 node_modules/
-index.d.ts
-index.d.ts.map
-index.js
-index.js.map
+implementation.d.ts
+implementation.d.ts.map
+implementation.js
+implementation.js.map
+index-cjs.d.ts
+index-cjs.d.ts.map
+index-cjs.js
+index-cjs.js.map
+index-esm.d.ts
+index-esm.d.ts.map
+index-esm.js
+index-esm.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,13 @@ implementation.d.ts
 implementation.d.ts.map
 implementation.js
 implementation.js.map
+implementation.mjs
+implementation.mjs.map
 index-cjs.d.ts
 index-cjs.d.ts.map
 index-cjs.js
 index-cjs.js.map
 index-esm.d.ts
 index-esm.d.ts.map
-index-esm.js
-index-esm.js.map
+index-esm.mjs
+index-esm.mjs.map

--- a/implementation.ts
+++ b/implementation.ts
@@ -1,4 +1,4 @@
-interface IUnderlyingMap<K, V> {
+export interface IUnderlyingMap<K, V> {
 	has(key: K): boolean
 	get(key: K): V | undefined
 	delete(key: K): boolean

--- a/index-cjs.ts
+++ b/index-cjs.ts
@@ -1,0 +1,7 @@
+import mapFactory from './implementation.js'
+
+// Improve compatibility with ES module loaders
+Object.defineProperty(mapFactory, '__esModule', {value: true})
+Object.defineProperty(mapFactory, 'default', {enumerable: true, value: mapFactory})
+
+export = mapFactory

--- a/index-cjs.ts
+++ b/index-cjs.ts
@@ -1,7 +1,3 @@
 import mapFactory from './implementation.js'
 
-// Improve compatibility with ES module loaders
-Object.defineProperty(mapFactory, '__esModule', {value: true})
-Object.defineProperty(mapFactory, 'default', {enumerable: true, value: mapFactory})
-
 export = mapFactory

--- a/index-esm.ts
+++ b/index-esm.ts
@@ -1,0 +1,17 @@
+import mapFactory from './implementation.js'
+
+export * from './implementation.js'
+export default mapFactory
+
+// work-around for https://github.com/webpack/webpack/issues/6584
+try { // we cannot check for existence of the module object, Webpack would "simplify" the condition to false.
+	// Check if we are dealing with Webpack's harmony-module.js wrapper.
+	// @ts-ignore
+	if (Object.getOwnPropertyDescriptor(module, 'exports').writable === false) {
+		Object.defineProperty(mapFactory, '__esModule', {value: true})
+		Object.defineProperty(mapFactory, 'default', {enumerable: true, value: mapFactory})
+		// @ts-ignore
+		const realModule = Object.getPrototypeOf(module)
+		realModule.exports = mapFactory
+	}
+} catch {}

--- a/index-esm.ts
+++ b/index-esm.ts
@@ -14,4 +14,4 @@ try { // we cannot check for existence of the module object, Webpack would "simp
 		const realModule = Object.getPrototypeOf(module)
 		realModule.exports = mapFactory
 	}
-} catch {}
+} catch {} // tslint:disable-line:no-empty

--- a/index-esm.ts
+++ b/index-esm.ts
@@ -2,16 +2,3 @@ import mapFactory from './implementation.js'
 
 export * from './implementation.js'
 export default mapFactory
-
-// work-around for https://github.com/webpack/webpack/issues/6584
-try { // we cannot check for existence of the module object, Webpack would "simplify" the condition to false.
-	// Check if we are dealing with Webpack's harmony-module.js wrapper.
-	// @ts-ignore
-	if (Object.getOwnPropertyDescriptor(module, 'exports').writable === false) {
-		Object.defineProperty(mapFactory, '__esModule', {value: true})
-		Object.defineProperty(mapFactory, 'default', {enumerable: true, value: mapFactory})
-		// @ts-ignore
-		const realModule = Object.getPrototypeOf(module)
-		realModule.exports = mapFactory
-	}
-} catch {} // tslint:disable-line:no-empty

--- a/index-tests.ts
+++ b/index-tests.ts
@@ -1,4 +1,4 @@
-import keyMaster from './index'
+import keyMaster from './implementation'
 
 interface IUnderlyingMap<K, V> {
 	has(key: K): boolean

--- a/index-tests.ts
+++ b/index-tests.ts
@@ -1,4 +1,4 @@
-import keyMaster = require('./index')
+import keyMaster from './index'
 
 interface IUnderlyingMap<K, V> {
 	has(key: K): boolean

--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@ interface IUnderlyingMap<K, V> {
 	set(key: K, value: V): void
 }
 
-interface IManagedMap<K, V> {
+export interface IManagedMap<K, V> {
 	has(key: K): boolean
 	get(key: K): V
 	delete(key: K): boolean

--- a/index.ts
+++ b/index.ts
@@ -15,7 +15,7 @@ export interface IManagedMap<K, V> {
 
 type ValueFactory<K, V> = (key: K) => V
 
-function mapFactory<K, V>(
+export default function mapFactory<K, V>(
 	factory: ValueFactory<K, V>,
 	map: IUnderlyingMap<K, V> = new Map<K, V>(),
 ): IManagedMap<K, V> {
@@ -35,5 +35,3 @@ function mapFactory<K, V>(
 		getUnderlyingDataStructure: (): IUnderlyingMap<K, V> => map,
 	}
 }
-
-export = mapFactory

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "compile:cjs": "npx tsc --project tsconfig-cjs.json",
     "compile:esm": "npx tsc --project tsconfig-esm.json",
     "build": "rm -rf cjs/ esm/ && npm run compile:cjs && npm run compile:esm",
-    "test": "tslint --project . && tsc --project tsconfig-tests.json && tape test.js && jsmd readme.md"
+    "test": "npm run build && tslint --project . && tsc --project tsconfig-tests.json && tape test.js && jsmd readme.md"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "key-master",
   "version": "4.1.0",
   "description": "hashmap + constructor function = a hashmap you don't have to check before calling get()",
-  "main": "cjs/index.js",
-  "module": "esm/index.js",
-  "types": "esm/index.d.ts",
+  "main": "cjs/index-cjs.js",
+  "module": "esm/index-esm.js",
+  "types": "esm/implementation.d.ts",
   "scripts": {
-    "compile:cjs": "npx tsc --project . --outDir cjs",
-    "compile:esm": "npx tsc --project . --outDir esm --module es2015",
-    "build": "npm run compile:cjs && npm run compile:esm",
+    "compile:cjs": "npx tsc --project tsconfig-cjs.json",
+    "compile:esm": "npx tsc --project tsconfig-esm.json",
+    "build": "rm -rf cjs/ esm/ && npm run compile:cjs && npm run compile:esm",
     "test": "tslint --project . && tsc --project tsconfig-tests.json && tape test.js && jsmd readme.md"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,13 @@
   "name": "key-master",
   "version": "4.0.0",
   "description": "hashmap + constructor function = a hashmap you don't have to check before calling get()",
-  "main": "index.js",
+  "main": "cjs/index.js",
+  "module": "esm/index.js",
+  "types": "esm/index.d.ts",
   "scripts": {
-    "compile": "npx tsc --project .",
-    "prepublishOnly": "npm run compile",
+    "compile:cjs": "npx tsc --project . --outDir cjs",
+    "compile:esm": "npx tsc --project . --outDir esm --module es2015",
+    "prepublishOnly": "npm run compile:cjs && npm run compile:esm",
     "test": "npx tslint --project . && npx tsc --project tsconfig-tests.json && tape test.js && jsmd readme.md"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,12 +2,10 @@
   "name": "key-master",
   "version": "4.1.0",
   "description": "hashmap + constructor function = a hashmap you don't have to check before calling get()",
-  "main": "cjs/index-cjs.js",
-  "module": "esm/index-esm.js",
-  "types": "esm/implementation.d.ts",
+  "main": "./cjs/index-cjs.js",
   "scripts": {
     "compile:cjs": "npx tsc --project tsconfig-cjs.json",
-    "compile:esm": "npx tsc --project tsconfig-esm.json",
+    "compile:esm": "npx tsc --project tsconfig-esm.json && mv esm/implementation.js esm/implementation.mjs && mv esm/implementation.js.map esm/implementation.mjs.map && mv esm/index-esm.js esm/index-esm.mjs && mv esm/index-esm.js.map esm/index-esm.mjs.map && sed -i \"s/implementation.js';/implementation.mjs'/\" esm/index-esm.mjs",
     "build": "rm -rf cjs/ esm/ && npm run compile:cjs && npm run compile:esm",
     "test": "npm run build && tslint --project . && tsc --project tsconfig-tests.json && tape test.js && jsmd readme.md"
   },

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Seen this pattern before?
 
 <!-- js
 require('ts-node/register')
-var keyMaster = require('.').default
+var keyMaster = require('.')
 function actuallyDoStuff() {
 
 }
@@ -44,7 +44,9 @@ actuallyDoStuff(map.get('howdy'))
 # Usage
 
 - Install: `npm install key-master`
-- Use: `const keyMaster = require('key-master').default`
+- Use: `const keyMaster = require('key-master')` or
+  `import keyMaster from 'key-master'` (the package provides both CommonJS and
+  ES modules entry points)
 
 This library uses ES2015 syntax, so if you're deploying to IE11, you'll need to be transpiling your project with Babel or something.
 

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Seen this pattern before?
 
 <!-- js
 require('ts-node/register')
-var keyMaster = require('.')
+var keyMaster = require('.').default
 function actuallyDoStuff() {
 
 }
@@ -44,7 +44,7 @@ actuallyDoStuff(map.get('howdy'))
 # Usage
 
 - Install: `npm install key-master`
-- Use: `const keyMaster = require('key-master')`
+- Use: `const keyMaster = require('key-master').default`
 
 This library uses ES2015 syntax, so if you're deploying to IE11, you'll need to be transpiling your project with Babel or something.
 

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 require(`ts-node/register`)
 const test = require(`tape`)
-const KeyMaster = require(`./index.ts`).default
+const KeyMaster = require(`./implementation`).default
 
 function testWithMapConstructor(t, Constructor) {
 	const newMap = () => Constructor ? new Constructor() : undefined

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 require('ts-node/register')
 const test = require('tape')
-const KeyMaster = require('./index.ts')
+const KeyMaster = require('./index.ts').default
 
 function testWithMapConstructor(t, Constructor) {
 	const newMap = () => Constructor ? new Constructor() : undefined

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./cjs"
+  },
+  "include": [
+    "implementation.ts",
+    "index-cjs.ts"
+  ]
+}

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "es2015"
+  },
+  "include": [
+    "implementation.ts",
+    "index-esm.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "rootDir": ".",
+    "outDir": "./esm",
 
     "strict": true,
 
@@ -15,6 +16,6 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": [
-    "index.ts"
+    "implementation.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "rootDir": ".",
 
     "strict": true,
 


### PR DESCRIPTION
The current code makes it impossible for proper support of ES modules and use with native ES module support in the browser.

This PR attempts to improve the state of things.

Unfortunately, the backwards compatibility might get broken for older projects that do not get compiled with ES module compatibility in mind and rely strictly on CJS modules mechanics. Therefore I would like to suggest bumping the major version number before publishing this change.